### PR TITLE
Fix health endpoint and imports/exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-  "env": {
-    "test": {
-      "plugins": ["@babel/plugin-transform-modules-commonjs"]
-    }
-  }
-}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,4 +37,4 @@ jobs:
         run: npm start &
 
       - name: Check if server is up
-        run: curl localhost:3001/health | grep "OK"
+        run: curl localhost:3001/api/health | grep "OK"

--- a/app.js
+++ b/app.js
@@ -1,12 +1,12 @@
-import dotenv from 'dotenv';
-import express from 'express';
-import cors from 'cors';
-import { UserRouter } from './resources/user/userController.js';
-import { FileRouter } from './resources/file/fileController.js';
+const dotenv = require('dotenv');
+const express = require('express');
+const cors = require('cors');
+const { UserRouter } = require('./resources/user/userController.js');
+const { FileRouter } = require('./resources/file/fileController.js');
 
 dotenv.config({ path: `./.env.${process.env.NODE_ENV}` });
 
-export const app = express();
+const app = express();
 
 app.use(cors({ origin: process.env.CLIENT_ORIGIN, credentials: true }));
 app.use(express.json());
@@ -15,12 +15,8 @@ app.use(express.urlencoded({ extended: true }));
 app.use('/api/users', UserRouter);
 app.use('/api/files', FileRouter);
 
-app.get('/health', (_, res) => {
+app.get('/api/health', (_, res) => {
   res.status(200).send('OK');
 });
 
-// TODO: decide to serve static assets from service directly or use S3/CloudFront
-// app.use(express.static('../client/build'));
-// app.get('*', (_, res) => {
-//   res.sendFile('index.html', { root: '../client/build' });
-// });
+module.exports = { app };

--- a/app.test.js
+++ b/app.test.js
@@ -1,6 +1,6 @@
-import { apiClient, setupApp, teardownApp } from './utils/testing-utils.js';
-import { app } from './app.js';
-import mongoose from 'mongoose';
+const { apiClient, setupApp, teardownApp } = require('./utils/testing-utils.js');
+const { app } = require('./app.js');
+const mongoose = require('mongoose');
 
 let server;
 
@@ -13,8 +13,8 @@ describe('App', () => {
     await teardownApp(server, mongoose);
   });
 
-  test('returns 200 on /health', async () => {
-    const response = await apiClient.get('/health');
+  test('returns 200 on /api/health', async () => {
+    const response = await apiClient.get('/api/health');
     expect(response.status).toBe(200);
   });
 });

--- a/aws-cdk/lib/aws-cdk-fargate-stack.js
+++ b/aws-cdk/lib/aws-cdk-fargate-stack.js
@@ -63,15 +63,13 @@ class TileTogetherServiceStack extends Stack {
     };
 
     // eslint-disable-next-line no-unused-vars
-    const fargateService = new ApplicationLoadBalancedFargateService(
-      this,
-      'tiletogether-service',
+    const fargateService = new ApplicationLoadBalancedFargateService(this, 'tiletogether-service',
       {
         cluster,
         taskImageOptions,
         cpu: 256,
         memoryLimitMiB: 512,
-        desiredCount: 3,
+        desiredCount: 1,
         serviceName: 'tiletogether-service',
         taskSubnets: vpc.selectSubnets({
           subnetType: SubnetType.PRIVATE_WITH_EGRESS,
@@ -79,6 +77,12 @@ class TileTogetherServiceStack extends Stack {
         loadBalancer,
       },
     );
+
+    fargateService.targetGroup.configureHealthCheck({
+      path: '/api/health',
+      enabled: true,
+      healthyHttpCodes: '200',
+    });
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import dotenv from 'dotenv';
-import mongoose from 'mongoose';
-import { app } from './app.js';
+const dotenv = require('dotenv');
+const mongoose = require('mongoose');
+const { app } = require('./app.js');
 dotenv.config({ path: `./.env.${process.env.NODE_ENV}` });
 
 async function main () {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('jest').Config} */
+const config = {
+  modulePathIgnorePatterns: ['<rootDir>/aws-cdk'],
+};
+
+module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "mongoose": "^6.6.0"
       },
       "devDependencies": {
-        "@babel/plugin-transform-modules-commonjs": "^7.18.6",
         "@faker-js/faker": "^7.5.0",
         "axios": "^0.27.2",
         "eslint": "8.22.0",
@@ -562,24 +561,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.18.6.tgz",
-      "integrity": "sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/helper-simple-access": "^7.18.6",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1590,15 +1571,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
-      }
-    },
-    "node_modules/babel-plugin-dynamic-import-node": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-      "dev": true,
-      "dependencies": {
-        "object.assign": "^4.1.0"
       }
     },
     "node_modules/babel-plugin-istanbul": {
@@ -6870,18 +6842,6 @@
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
-    "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.18.6.tgz",
-      "integrity": "sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-transforms": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/helper-simple-access": "^7.18.6",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
-      }
-    },
     "@babel/template": {
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
@@ -7689,15 +7649,6 @@
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
-      }
-    },
-    "babel-plugin-dynamic-import-node": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-      "dev": true,
-      "requires": {
-        "object.assign": "^4.1.0"
       }
     },
     "babel-plugin-istanbul": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "mongoose": "^6.6.0"
   },
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "^7.18.6",
     "@faker-js/faker": "^7.5.0",
     "axios": "^0.27.2",
     "eslint": "8.22.0",
@@ -31,6 +30,5 @@
     "eslint-plugin-n": "^15.2.5",
     "eslint-plugin-promise": "^6.0.1",
     "jest": "^29.0.3"
-  },
-  "type": "module"
+  }
 }

--- a/resources/file/fileController.js
+++ b/resources/file/fileController.js
@@ -1,7 +1,7 @@
-import express from 'express';
-// import { File } from './fileSchema.js';
+const express = require('express');
+// const { File } = require('./fileSchema.js');
 
-export const FileRouter = express.Router();
+const FileRouter = express.Router();
 
 /* FileRouter.post('/', getCommunityFiles);
 FileRouter.get('/search/', search);
@@ -18,3 +18,5 @@ async function search (req, res) {
 async function getUserFiles (req, res) {
 
 } */
+
+module.exports = { FileRouter };

--- a/resources/user/userController.js
+++ b/resources/user/userController.js
@@ -1,9 +1,9 @@
-import { identifyIfLoggedIn, isNotLoggedIn } from './userMiddleWare.js';
-import express from 'express';
-import { User } from './userSchema.js';
-import _ from 'lodash';
+const { identifyIfLoggedIn, isNotLoggedIn } = require('./userMiddleWare.js');
+const express = require('express');
+const { User } = require('./userSchema.js');
+const _ = require('lodash');
 
-export const UserRouter = express.Router();
+const UserRouter = express.Router();
 
 UserRouter.get('/', identifyIfLoggedIn, getUser);
 UserRouter.post('/', isNotLoggedIn, postUser);
@@ -89,3 +89,5 @@ async function postUser (req, res) {
     email: user.email,
   });
 }
+
+module.exports = { UserRouter };

--- a/resources/user/userController.test.js
+++ b/resources/user/userController.test.js
@@ -1,8 +1,8 @@
-import mongoose from 'mongoose';
-import { User } from './userSchema.js';
-import _ from 'lodash';
-import { apiClient, setupApp, teardownApp } from '../../utils/testing-utils.js';
-import { app } from '../../app.js';
+const mongoose = require('mongoose');
+const { User } = require('./userSchema.js');
+const _ = require('lodash');
+const { apiClient, setupApp, teardownApp } = require('../../utils/testing-utils.js');
+const { app } = require('../../app.js');
 
 let user;
 let server;

--- a/resources/user/userMiddleWare.js
+++ b/resources/user/userMiddleWare.js
@@ -1,6 +1,6 @@
-import { User } from './userSchema.js';
+const { User } = require('./userSchema.js');
 
-export async function isNotLoggedIn (req, res, next) {
+async function isNotLoggedIn (req, res, next) {
   if (req.headers.authorization == null) {
     next();
     return;
@@ -18,7 +18,7 @@ export async function isNotLoggedIn (req, res, next) {
   }
 }
 
-export async function isLoggedIn (req, res, next) {
+async function isLoggedIn (req, res, next) {
   if (req.headers.authorization == null) {
     next();
     return;
@@ -35,7 +35,7 @@ export async function isLoggedIn (req, res, next) {
   }
 }
 
-export async function identifyIfLoggedIn (req, _, next) {
+async function identifyIfLoggedIn (req, _, next) {
   if (req.headers.authorization == null) {
     next();
     return;
@@ -49,3 +49,5 @@ export async function identifyIfLoggedIn (req, _, next) {
   }
   next();
 }
+
+module.exports = { isNotLoggedIn, isLoggedIn, identifyIfLoggedIn };

--- a/resources/user/userSchema.js
+++ b/resources/user/userSchema.js
@@ -1,6 +1,7 @@
-import bcrypt from 'bcrypt';
-import mongoose, { Schema } from 'mongoose';
-import jwt from 'jsonwebtoken';
+const bcrypt = require('bcrypt');
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+const jwt = require('jsonwebtoken');
 
 function hashPassword (password) {
   if (password && password.length >= 8) {
@@ -10,7 +11,7 @@ function hashPassword (password) {
   return password;
 }
 
-export const UserSchema = new Schema({
+const UserSchema = new Schema({
   username: {
     type: String,
     required: [true, 'Username is required'],
@@ -64,4 +65,6 @@ UserSchema.methods.generateAuthToken = function () {
   return jwt.sign(payload, secret, options);
 };
 
-export const User = mongoose.model('User', UserSchema);
+const User = mongoose.model('User', UserSchema);
+
+module.exports = { UserSchema, User };

--- a/utils/testing-utils.js
+++ b/utils/testing-utils.js
@@ -1,5 +1,5 @@
-import dotenv from 'dotenv';
-import axios from 'axios';
+const dotenv = require('dotenv');
+const axios = require('axios');
 dotenv.config({ path: './.env.testing' });
 
 function wait (ms) {


### PR DESCRIPTION
# Notes
* ES6 imports/exports kept causing weird issues again with Jest so converted again to requires
* Fixed incorrect health check setup in the CDK (it was checking '/' by default which returned 404 and caused the containers to be repeatedly killed and restarted)
* Health check path is now '/api/health'

# Testing
* npm test
* Deployed from personal repos to aws