### PR TITLE
Fix closed PR github action

### DIFF
--- a/.github/workflows/closed-pull-request.yml
+++ b/.github/workflows/closed-pull-request.yml
@@ -1,13 +1,10 @@
 name: Deploy
 on:
-  pull_request:
-    types: [closed]
   push:
     branches:
       - main
 jobs:
   deploy-nodejs-app-fargate:
-    if: github.event.pull_request.merged == true || github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61459043/197243513-aa0a1a6d-a797-42b5-8640-cd57e1830df5.png)
Screenshot from https://github.com/team-orange-cse416/tiletogether-service/actions

# Notes
* Deployments were being run twice on PR merge (both on PR close and on push to main)
* Fixed closed-pull-request.yml so that it only runs once (on push to main only)

# Testing
* Deployed from personal repo and verified new yml works