### PR TITLE
Fix tests and add likedFiles field to userSchema

### DIFF
--- a/resources/file/fileController.test.js
+++ b/resources/file/fileController.test.js
@@ -2,7 +2,8 @@ const { setupApp, teardownApp, apiClient } = require('../../utils/testingUtils')
 const { app } = require('../../app');
 const mongoose = require('mongoose');
 const { User } = require('../user/userSchema');
-const { File } = require('./fileSchema');
+const { File, editFileFields, viewFileFields } = require('./fileSchema');
+const _ = require('lodash');
 
 let server;
 
@@ -10,19 +11,18 @@ let server;
 jest.setTimeout(100000);
 
 describe('Connect to MongoDB', () => {
-  let user, userInstance, apiClientConfig;
+  let user, apiClientConfig;
 
   beforeAll(async () => {
     server = await setupApp(app, mongoose);
     await File.deleteTestFiles();
     await User.deleteTestUsers();
 
-    user = User.newTestUser();
-    userInstance = await User.create(user);
+    user = await User.create(User.newTestUser());
     apiClientConfig = {
       headers: {
         withCredentials: true,
-        Authorization: `Bearer ${userInstance.generateAuthToken()}`,
+        Authorization: `Bearer ${user.generateAuthToken()}`,
       },
     };
   });
@@ -34,12 +34,19 @@ describe('Connect to MongoDB', () => {
   });
 
   describe('File API lets user', () => {
-    describe('upload file', () => {
+    describe('create a file', () => {
       test('status 200', async () => {
         const validFile = await File.newTestFile(user.username);
         const res = await apiClient.post('/api/files', validFile, apiClientConfig);
         expect(res.status).toBe(200);
+        const fileInDb = await File.findById(res.data.file.id);
+        expect(fileInDb).not.toBe(null);
+
+        const fileFields = Object.keys(res.data.file);
+        const difference = _.difference(editFileFields, fileFields);
+        expect(difference).toEqual([]);
       });
+
       test('status 400', async () => {
         const invalidFile = await File.newTestFile(user.username);
         invalidFile.name = '';
@@ -50,17 +57,24 @@ describe('Connect to MongoDB', () => {
     });
 
     describe('like a file', () => {
-      let file, fileInstance, validFileId;
+      let file, validFileId;
 
       beforeAll(async () => {
         file = await File.newTestFile(user.username);
-        fileInstance = await File.create(file);
-        validFileId = fileInstance._id;
+        file = await File.create(file);
+        validFileId = file._id;
       });
 
       test('status 200', async () => {
         const res = await apiClient.post(`/api/files/${validFileId}/like`, { liked: true }, apiClientConfig);
         expect(res.status).toBe(200);
+        file = await File.findById(validFileId);
+
+        const likedFile = await File.findOne({ _id: file._id, 'likes.authorUsername': user.username });
+        expect(likedFile).not.toBeNull();
+
+        user = await User.findById(user._id);
+        expect(user.likedFiles).toContainEqual(validFileId);
       });
 
       test('status 400', async () => {
@@ -71,6 +85,13 @@ describe('Connect to MongoDB', () => {
       test('status 200 for unliking', async () => {
         const res200Unliking = await apiClient.post(`/api/files/${validFileId}/like`, { liked: false }, apiClientConfig);
         expect(res200Unliking.status).toBe(200);
+        file = await File.findById(validFileId);
+
+        const unlikedFile = await File.findOne({ _id: file._id, 'likes.authorUsername': user.username });
+        expect(unlikedFile).toBeNull();
+
+        user = await User.findById(user._id);
+        expect(user.likedFiles).not.toContainEqual(validFileId);
       });
 
       test('status 404', async () => {
@@ -92,6 +113,9 @@ describe('Connect to MongoDB', () => {
       test('status 200', async () => {
         const res = await apiClient.post(`/api/files/${validFileId}/comment`, { content: 'test comment' }, apiClientConfig);
         expect(res.status).toBe(200);
+
+        const commentedFile = await File.findOne({ _id: validFileId, 'comments.authorUsername': user.username });
+        expect(commentedFile).not.toBeNull();
       });
 
       test('status 404', async () => {
@@ -113,6 +137,10 @@ describe('Connect to MongoDB', () => {
       test('status 200', async () => {
         const res = await apiClient.get(`/api/files/${validFileId}`, apiClientConfig);
         expect(res.status).toBe(200);
+
+        const fileFields = Object.keys(res.data.file);
+        const difference = _.difference(viewFileFields, fileFields);
+        expect(difference).toEqual([]);
       });
 
       test('status 404', async () => {
@@ -144,6 +172,10 @@ describe('Connect to MongoDB', () => {
       test('status 200', async () => {
         const res = await apiClient.get(`/api/files/${validFileId}/edit`, apiClientConfig);
         expect(res.status).toBe(200);
+
+        const fileFields = Object.keys(res.data.file);
+        const difference = _.difference(editFileFields, fileFields);
+        expect(difference).toEqual([]);
       });
 
       test('status 404', async () => {

--- a/resources/file/fileSchema.js
+++ b/resources/file/fileSchema.js
@@ -6,6 +6,9 @@ const mongoose = require('mongoose');
 const tags = ['furniture', 'trees', 'buildings', 'vehicles', 'people', 'animals', 'plants', 'food', 'weapons', 'misc'];
 const tileDimensions = [16, 32, 64, 128, 256];
 
+const editFileFields = ['id', 'height', 'name', 'rootLayer', 'sharedWith', 'tags', 'tileDimension', 'tilesets', 'type', 'visibility', 'width'];
+const viewFileFields = ['id', 'authorUsername', 'comments', 'createdAt', 'height', 'name', 'tags', 'tileDimension', 'tilesets', 'type', 'updatedAt', 'width'];
+
 const layerSchema = Schema({
   name: { type: String, required: true },
   opacity: { type: Number, default: 1, required: true, min: 0, max: 1 },
@@ -82,4 +85,4 @@ fileSchema.statics.deleteTestFiles = async function () {
 const Layer = mongoose.model('Layer', layerSchema);
 const File = mongoose.model('File', fileSchema);
 
-module.exports = { File, Layer };
+module.exports = { File, Layer, editFileFields, viewFileFields };

--- a/resources/user/userController.js
+++ b/resources/user/userController.js
@@ -52,9 +52,7 @@ async function postUser (req, res) {
   const { username, password, confirmPassword, email } = req.body;
   let errors = {};
 
-  if (confirmPassword == null || confirmPassword.trim() === '') {
-    errors.confirmPassword = 'Confirm password is required';
-  } else if (password !== confirmPassword) {
+  if (password !== confirmPassword) {
     errors.confirmPassword = 'Passwords do not match';
   }
 

--- a/resources/user/userSchema.js
+++ b/resources/user/userSchema.js
@@ -32,6 +32,10 @@ const UserSchema = new Schema({
     required: [true, 'Email is required'],
     match: [/^[^\s@]+@[^\s@]+\.[^\s@]+$/, 'Invalid email'],
   },
+  likedFiles: [{
+    type: Schema.Types.ObjectId,
+    ref: 'File',
+  }],
 });
 
 UserSchema.statics.authenticate = async function (email, password) {


### PR DESCRIPTION
# Notes
* Didn't notice that when I refactored the fileController tests in this PR #44, I somehow removed all the non-status expect tests
* That made the tests only check for response status codes
* Added back in the test logic in this commit
* Also updated likeFile so that it updates a likedFiles field in the User object

# Testing
* npm test