### PR TITLE
Update mock data scripts, fixes to connect to dashboard

### DIFF
--- a/resources/file/fileSchema.js
+++ b/resources/file/fileSchema.js
@@ -7,7 +7,7 @@ const tags = ['furniture', 'trees', 'buildings', 'vehicles', 'people', 'animals'
 const tileDimensions = [16, 32, 64, 128, 256];
 
 const editFileFields = ['id', 'height', 'name', 'rootLayer', 'sharedWith', 'tags', 'tileDimension', 'tilesets', 'type', 'publishedAt', 'width'];
-const viewFileFields = ['id', 'authorUsername', 'comments', 'likeCount', 'commentCount', 'height', 'name', 'tags', 'tileDimension', 'tilesets', 'type', 'updatedAt', 'width', 'publishedAt'];
+const viewFileFields = ['id', 'authorUsername', 'comments', 'likeCount', 'commentCount', 'height', 'name', 'tags', 'tileDimension', 'tilesets', 'type', 'updatedAt', 'width', 'publishedAt', 'likes'];
 
 const layerSchema = Schema({
   name: { type: String, required: true },

--- a/scripts/addMockData.js
+++ b/scripts/addMockData.js
@@ -1,11 +1,14 @@
 const { app } = require('../app');
 const mongoose = require('mongoose');
-const { setupApp, teardownApp } = require('./testingUtils');
+const { setupApp, teardownApp } = require('../utils/testingUtils');
 const { User } = require('../resources/user/userSchema');
 const { File } = require('../resources/file/fileSchema');
 const _ = require('lodash');
-const numUsers = 3;
-const numFiles = 30;
+const dotenv = require('dotenv');
+dotenv.config({ path: '../.env.development' });
+
+const numUsers = 5;
+const numFiles = 50;
 
 const users = [];
 const files = [];
@@ -18,6 +21,14 @@ async function main () {
     const user = await User.create(User.newTestUser());
     users.push(user);
   }
+
+  // Create user to login with
+  let testUser = User.newTestUser();
+  testUser.username = 'test';
+  testUser.password = 'password123';
+  testUser.email = 'test@email.com';
+  testUser = await User.create(testUser);
+  users.push(testUser);
 
   // Create files
   for (let i = 0; i < numFiles; i++) {

--- a/scripts/deleteMockData.js
+++ b/scripts/deleteMockData.js
@@ -1,8 +1,10 @@
 const { app } = require('../app');
 const mongoose = require('mongoose');
-const { setupApp, teardownApp } = require('./testingUtils');
+const { setupApp, teardownApp } = require('../utils/testingUtils');
 const { User } = require('../resources/user/userSchema');
 const { File } = require('../resources/file/fileSchema');
+const dotenv = require('dotenv');
+dotenv.config({ path: '../.env.development' });
 
 async function main () {
   const server = await setupApp(app, mongoose);


### PR DESCRIPTION
# Notes
* Used scripts to fill local and Atlas db to test frontend dashboared connection to API
* You can use test user with email "test@email.com", username "test", and password "password123" to login every time you destroy and recreate the tiletogether database in mongodb
* Updated dashboard to connect to API in this PR: https://github.com/team-orange-cse416/tiletogether-static-assets/pull/4
* Added a your_files mode to make fetching the user's files easier from the frontend
* Searching, sorting, filtering, paginating files seems to work from frontend
* Default search mode and your_files mode also seems to work from frontend

# Testing
* Deployed from personal repo
* npm test