### PR TITLE
Fix deregister user test

### DIFF
--- a/resources/user/userController.test.js
+++ b/resources/user/userController.test.js
@@ -3,6 +3,7 @@ const { User } = require('./userSchema.js');
 const _ = require('lodash');
 const { apiClient, setupApp, teardownApp } = require('../../utils/testingUtils.js');
 const { app } = require('../../app.js');
+const { wait } = require('../../utils/testingUtils');
 
 let user;
 let server;
@@ -69,6 +70,7 @@ describe('Connect to MongoDB', () => {
           password: user.password,
         },
       });
+      await wait(100);
       expect(await User.findOne({ username: user.username })).toBeNull();
     });
   });

--- a/resources/user/userSchema.js
+++ b/resources/user/userSchema.js
@@ -70,9 +70,8 @@ UserSchema.statics.newTestUser = function () {
   username = username.slice(0, 20 - suffix.length);
   username += suffix;
 
-  if (username.length > 20) {
-    throw new Error(`Username ${username} is too long`);
-  }
+  // remove all non-lowercase alphanumeric characters
+  username = username.replace(/[^a-z0-9]/g, '');
 
   return {
     username,


### PR DESCRIPTION
# Notes
* Deregister test was failing here https://github.com/team-orange-cse416/tiletogether-service/actions/runs/3315714922/jobs/5476651849
* Might be because it was checking to see if the user was deleted before the user was finished being deleted so added a delay
* The generated test users also sometimes seemed to have invalid characters in their username (due to faker probably) so added line to strip all non alphanumeric lowercase characters from the username in UserSchema.statics.newTestUser